### PR TITLE
Added metalog probability distribution for manipulating audio speed and frequency

### DIFF
--- a/pogbot.nix
+++ b/pogbot.nix
@@ -1,6 +1,6 @@
 { pkgs, ...} :
 let 
-    python = pkgs.python3.withPackages(ps: with ps; [ python-dotenv aiohttp discordpy pynacl six numpy ] );
+    python = pkgs.python3.withPackages(ps: with ps; [ python-dotenv aiohttp discordpy pynacl six numpy metalogistic ] );
 
 in
 {

--- a/pogbot.nix
+++ b/pogbot.nix
@@ -1,6 +1,6 @@
 { pkgs, ...} :
 let 
-    python = pkgs.python3.withPackages(ps: with ps; [ python-dotenv aiohttp discordpy pynacl six numpy metalogistic ] );
+    python = pkgs.python3.withPackages(ps: with ps; [ python-dotenv aiohttp discordpy pynacl six metalogistic ] );
 
 in
 {

--- a/shell.nix
+++ b/shell.nix
@@ -2,5 +2,5 @@ let pkgs = import <nixpkgs> {};
 in
   pkgs.mkShell {
     name = "pogbot-env";
-    buildInputs = with pkgs; [ python38 python38Packages.aiohttp python38Packages.discordpy python38Packages.python-dotenv python38Packages.six ffmpeg python38Packages.numpy python38Packages.metalogistic ];
+    buildInputs = with pkgs; [ python38 python38Packages.aiohttp python38Packages.discordpy python38Packages.python-dotenv python38Packages.six ffmpeg python38Packages.metalogistic ];
   }

--- a/shell.nix
+++ b/shell.nix
@@ -2,5 +2,5 @@ let pkgs = import <nixpkgs> {};
 in
   pkgs.mkShell {
     name = "pogbot-env";
-    buildInputs = with pkgs; [ python38 python38Packages.aiohttp python38Packages.discordpy python38Packages.python-dotenv python38Packages.six ffmpeg python38Packages.numpy ];
+    buildInputs = with pkgs; [ python38 python38Packages.aiohttp python38Packages.discordpy python38Packages.python-dotenv python38Packages.six ffmpeg python38Packages.numpy python38Packages.metalogistic ];
   }


### PR DESCRIPTION
A [metalog distribution](https://en.wikipedia.org/wiki/Metalog_distribution) allows for flexibly-shaped and bounded distributions based on data along. The Python package [metalogistic](https://pypi.org/project/metalogistic/) provides a SciPy-compatible interface for this distribution.

Tuning is done by manipulating the mean (currently 100%), the upper and lower bounds of the data (currently 50% and 200%, respectively) and the range of percentiles which should sample at or near the mean (currently 25%). A [cumulative distribution function](https://en.wikipedia.org/wiki/Cumulative_distribution_function) shows the values at a given percentile:

![speed_distribution](https://user-images.githubusercontent.com/5421969/125169774-b215d600-e179-11eb-9d80-56d92cc2de57.png)

Approximately 25% of samples should return at or near the mean, with the remaining 75% being evenly divided to the range `[0.5, 1.0]` and `[1.0, 2.0]`. The distribution is bounded, therefore no samples will return outside of the range `[0.5, 2.0]`.